### PR TITLE
fix compile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+sudo: false
+go:
+- 1.10.x
+before_script:
+- GO_FILES=$(find . -iname '*.go' -type f | grep -v /test/ | grep -v /cmd/)
+script:
+- test -z $(gofmt -s -l $GO_FILES)
+- go vet $GO_FILES

--- a/bankTime.go
+++ b/bankTime.go
@@ -26,7 +26,7 @@ func NewBankTime(t time.Time) *BankTime {
 	c := cal.NewCalendar()
 	cal.AddUsHolidays(c)
 	c.Observed = cal.ObservedMonday
-	est, _ = time.LoadLocation("America/New_York")
+	est, _ := time.LoadLocation("America/New_York")
 	t = t.In(est)
 	bt := &BankTime{time: t, cal: c}
 


### PR DESCRIPTION
Previously, 

```
$ go get github.com/moov-io/banktime
# github.com/moov-io/banktime
../banktime/bankTime.go:29:2: undefined: est
../banktime/bankTime.go:30:11: undefined: est
```